### PR TITLE
Scripts

### DIFF
--- a/scripts/session-cleanup.sh
+++ b/scripts/session-cleanup.sh
@@ -66,8 +66,13 @@ fi
 
 # Optional: also ensure remote branch is gone (in case auto-delete is disabled)
 if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-  echo "Remote still has branch '$BRANCH'. Deleting at origin..."
-  git push origin --delete "$BRANCH" || true
+  echo "Remote still has branch '$BRANCH'. Deleting via GitHub API..."
+  REPO="${GH_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo '')}"
+  if [ -n "$REPO" ]; then
+    gh api "repos/${REPO}/git/refs/heads/${BRANCH}" -X DELETE || true
+  else
+    echo "Could not determine repo to delete remote branch. Set GH_REPO (e.g., ava-sig/obsidian-importer)." >&2
+  fi
 fi
 
 # Report status

--- a/scripts/smoke-meta.sh
+++ b/scripts/smoke-meta.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# [SIG-FLD-VAL-001] Declared in posture, amplified in field.
+# Meta smoke runner: ensures the project builds; extend with plugin-level smoke as needed.
+set -euo pipefail
+
+# Prefer a lightweight build if available
+if npm run -s build; then
+  echo "Smoke: build succeeded."
+  exit 0
+fi
+
+echo "Smoke: no build script or build failed." >&2
+exit 1

--- a/src/network/notionClient.ts
+++ b/src/network/notionClient.ts
@@ -1,0 +1,112 @@
+// [SIG-FLD-VAL-001] Declared in posture, amplified in field.
+// Notion Data Sources client — enforces Notion-Version and governance constraints.
+// Contracts: SIG-SYS-NOT-027 (Secrets & Privacy)
+
+export type NotionClientOptions = {
+  baseUrl?: string;
+  token?: string | null; // keep in memory by default; do not persist by default
+  allowLegacy?: boolean;
+  downgradeNote?: string;
+  timeoutMs?: number; // default 30000
+  maxRedirects?: number; // default 3
+};
+
+export type NotionRequest = {
+  path: string; // e.g., "/v1/data-sources/query"
+  method?: 'GET' | 'POST' | 'PATCH' | 'DELETE';
+  headers?: Record<string, string>;
+  body?: unknown;
+};
+
+export class NotionClient {
+  private baseUrl: string;
+  private token: string | null;
+  private allowLegacy: boolean;
+  private downgradeNote?: string;
+  private timeoutMs: number;
+  private maxRedirects: number;
+
+  constructor(opts: NotionClientOptions = {}) {
+    this.baseUrl = opts.baseUrl ?? 'https://api.notion.com';
+    this.token = opts.token ?? null;
+    this.allowLegacy = !!opts.allowLegacy;
+    this.downgradeNote = opts.downgradeNote;
+    this.timeoutMs = typeof opts.timeoutMs === 'number' ? opts.timeoutMs : 30000;
+    this.maxRedirects = typeof opts.maxRedirects === 'number' ? opts.maxRedirects : 3;
+  }
+
+  setToken(token: string | null) {
+    this.token = token;
+  }
+
+  async request<T = unknown>(req: NotionRequest): Promise<T> {
+    this.ensureCompliantPath(req.path);
+
+    const url = this.baseUrl.replace(/\/$/, '') + req.path;
+    const headers: Record<string, string> = {
+      'Notion-Version': '2025-09-03',
+      'Content-Type': 'application/json',
+      ...req.headers,
+    };
+    if (this.token) headers['Authorization'] = `Bearer ${this.token}`;
+
+    const controller = new AbortController();
+    const id = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    let redirectCount = 0;
+    let currentUrl = url;
+    let res: Response | null = null;
+
+    try {
+      // Simple redirect handling (maxRedirects)
+      // Note: Obsidian environment provides fetch; no Node imports here.
+      // @ts-ignore - fetch available in plugin runtime
+      while (true) {
+        res = await fetch(currentUrl, {
+          method: req.method ?? 'POST',
+          headers,
+          body: req.body != null ? JSON.stringify(req.body) : undefined,
+          signal: controller.signal,
+        });
+        const status = res.status;
+        if (status >= 300 && status < 400 && redirectCount < this.maxRedirects) {
+          const loc = res.headers.get('location');
+          if (!loc) break;
+          redirectCount++;
+          currentUrl = loc;
+          continue;
+        }
+        break;
+      }
+    } finally {
+      clearTimeout(id);
+    }
+
+    if (!res) throw new Error('Network error: no response');
+    if (res.status >= 400) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`Notion API error ${res.status}: ${text}`);
+    }
+
+    // @ts-ignore - Response#json exists
+    return (await res.json()) as T;
+  }
+
+  private ensureCompliantPath(path: string) {
+    // Enforce Data Sources usage; block legacy DB endpoints unless allowLegacy is set explicitly with a downgrade note
+    const lower = path.toLowerCase();
+    const usingDataSources = lower.includes('/data-sources');
+    const usingLegacyDb = lower.includes('/databases');
+
+    if (usingLegacyDb && !usingDataSources) {
+      if (!this.allowLegacy) {
+        throw new Error(
+          'Legacy Notion database endpoints are blocked. Use Data Sources (see docs/DOCS.md). If unavoidable, initialize client with { allowLegacy: true, downgradeNote } and document the downgrade.'
+        );
+      }
+      if (!this.downgradeNote) {
+        throw new Error('allowLegacy requires a downgradeNote to be provided.');
+      }
+    }
+  }
+}


### PR DESCRIPTION
# PR Summary

- What change is introduced?
- Why is this necessary now?
- How was this tested?

## Governance

- Glyph(s) referenced:
  - `SIG-FLD-VAL-001` — Declaration Echoes Return Amplified
- Contracts impacted (list IDs):
  - e.g., `SIG-SYS-NOT-027` — Secrets & Privacy

## Downgrade Notes (if any)

If using a legacy or less-preferred path (e.g., Notion legacy DB API instead of Data Sources), explain:
- Reason for downgrade:
- Scope and duration:
- Mitigations and plan to restore alignment:

## Checklist

- [ ] New/changed source files include the glyph header on the first lines:

```ts
// [SIG-FLD-VAL-001] Declared in posture, amplified in field.
```

- [ ] CI will run governance checks. If this is from a fork or CI cannot access governance repo, confirm local run:
  - `npm run check:glyph-header`
  - `npm run ci:pr`
  - `npm run validate:links`
  - `npm run perf:budgets`
  - `npm run fixtures:redact`
