### PR TITLE
feat(notion): scaffold importer modules, fixtures, docs; align tests with guidelines; enhance Notion client tests

### DIFF
--- a/.github/workflows/governance-ci.yml
+++ b/.github/workflows/governance-ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install dependencies (allow new dev deps)
         run: npm install
 
+      - name: Verify (lint + build)
+        run: npm run -s verify
+
       - name: Checkout governance (ava-sig/governance via PAT)
         uses: actions/checkout@v4
         with:

--- a/__tests__/notion-bases.spec.ts
+++ b/__tests__/notion-bases.spec.ts
@@ -1,0 +1,9 @@
+// [SIG-FLD-VAL-001] Declared in posture, amplified in field.
+import { describe, it, expect } from 'vitest';
+import { buildBaseYaml } from '../src/formats/notion-bases';
+
+describe.skip('Notion Bases', () => {
+  it('builds base YAML (to be implemented)', () => {
+    expect(typeof buildBaseYaml).toBe('function');
+  });
+});

--- a/__tests__/notion-client.spec.ts
+++ b/__tests__/notion-client.spec.ts
@@ -1,0 +1,9 @@
+// [SIG-FLD-VAL-001] Declared in posture, amplified in field.
+import { describe, it, expect } from 'vitest';
+import { NotionClient } from '../src/formats/notion-client';
+
+describe.skip('NotionClient (extended scenarios)', () => {
+  it('retries 429 with Retry-After (to be implemented)', () => {
+    expect(typeof NotionClient).toBe('function');
+  });
+});

--- a/__tests__/notion-convert.spec.ts
+++ b/__tests__/notion-convert.spec.ts
@@ -1,0 +1,9 @@
+// [SIG-FLD-VAL-001] Declared in posture, amplified in field.
+import { describe, it, expect } from 'vitest';
+import { convertBlockToMarkdown } from '../src/formats/notion-convert';
+
+describe.skip('Notion Convert', () => {
+  it('converts basic paragraph (to be implemented)', () => {
+    expect(typeof convertBlockToMarkdown).toBe('function');
+  });
+});

--- a/__tests__/obsidian-guidelines.spec.ts
+++ b/__tests__/obsidian-guidelines.spec.ts
@@ -1,0 +1,68 @@
+// [SIG-FLD-VAL-001] Declared in posture, amplified in field.
+// Static policy checks aligned with Obsidian plugin guidelines.
+import { describe, it, expect } from 'vitest';
+import fg from 'fast-glob';
+import fs from 'node:fs';
+import path from 'node:path';
+
+function read(file: string) {
+  return fs.readFileSync(file, 'utf8');
+}
+
+// Globs to scan only Notion importer runtime code (exclude unrelated legacy modules)
+const RUNTIME_GLOBS = [
+  'src/network/notionClient.ts',
+  'src/formats/notion-*.ts',
+  'src/ui/notion-*.ts',
+];
+
+// Helper: collect files
+function collectRuntimeFiles(): string[] {
+  const files = fg.sync(RUNTIME_GLOBS, { dot: false });
+  return files.map((f) => path.resolve(process.cwd(), f));
+}
+
+describe('Obsidian Plugin Policy (static)', () => {
+  const files = collectRuntimeFiles();
+
+  it('does not use window.app (avoid global app)', () => {
+    const offenders: string[] = [];
+    for (const f of files) {
+      const text = read(f);
+      if (/\bwindow\s*\.\s*app\b/.test(text)) offenders.push(f);
+    }
+    expect(offenders, `window.app used in: ${offenders.join(', ')}`).toHaveLength(0);
+  });
+
+  it('does not log to console (avoid noisy logs)', () => {
+    const offenders: string[] = [];
+    for (const f of files) {
+      const text = read(f);
+      // allow console.error in exceptional paths only if necessary; for now, block all console.* in runtime
+      if (/\bconsole\s*\./.test(text)) offenders.push(f);
+    }
+    expect(offenders, `console.* used in: ${offenders.join(', ')}`).toHaveLength(0);
+  });
+
+  it('does not use innerHTML/outerHTML/insertAdjacentHTML (XSS risk)', () => {
+    const offenders: string[] = [];
+    for (const f of files) {
+      const text = read(f);
+      if (/(innerHTML|outerHTML|insertAdjacentHTML)\s*=|\.(innerHTML|outerHTML|insertAdjacentHTML)\b/.test(text)) offenders.push(f);
+    }
+    expect(offenders, `dangerous HTML APIs used in: ${offenders.join(', ')}`).toHaveLength(0);
+  });
+
+  it('does not import Node/Electron APIs in runtime code (mobile safe)', () => {
+    const offenders: string[] = [];
+    for (const f of files) {
+      const text = read(f);
+      // Disallow common Node core modules in src runtime
+      if (/from\s+['"]node:/.test(text)) offenders.push(f);
+      if (/from\s+['"]fs['"]|require\(['"]fs['"]\)/.test(text)) offenders.push(f);
+      if (/from\s+['"]child_process['"]|require\(['"]child_process['"]\)/.test(text)) offenders.push(f);
+      if (/from\s+['"]electron['"]|require\(['"]electron['"]\)/.test(text)) offenders.push(f);
+    }
+    expect(offenders, `Node/Electron imports in: ${offenders.join(', ')}`).toHaveLength(0);
+  });
+});

--- a/docs/notion.md
+++ b/docs/notion.md
@@ -1,0 +1,19 @@
+# Notion Importer (Data Sources)
+
+This importer uses Notion Data Sources APIs, not legacy database endpoints.
+
+- Notion-Version is pinned for stability.
+- 429/5xx retries with backoff and Retry-After respect.
+- Legacy DB endpoints are blocked unless explicitly allowed with a downgrade note.
+
+Components:
+- `src/formats/notion-client.ts` — transport + governance guardrails
+- `src/formats/notion-convert.ts` — blocks to Markdown
+- `src/formats/notion-schema.ts` — property schema to front matter
+- `src/formats/notion-bases.ts` — views/filters/sorts/groups to YAML
+- `src/formats/notion-utils.ts` — helpers
+- `src/formats/notion-types.ts` — types
+
+Testing:
+- Add fixtures under `fixtures/notion/` for offline runs.
+- See `tests/network/notionClient.test.ts` for client basics.

--- a/fixtures/notion/blocks.json
+++ b/fixtures/notion/blocks.json
@@ -1,0 +1,4 @@
+[
+  { "object": "block", "id": "b1", "type": "paragraph", "paragraph": { "rich_text": [{"text": {"content": "Hello"}}] } },
+  { "object": "block", "id": "b2", "type": "to_do", "to_do": { "checked": false, "rich_text": [{"text": {"content": "Task"}}] } }
+]

--- a/fixtures/notion/data_source.json
+++ b/fixtures/notion/data_source.json
@@ -1,0 +1,5 @@
+{
+  "object": "data_source",
+  "id": "ds123",
+  "properties": {}
+}

--- a/fixtures/notion/page.json
+++ b/fixtures/notion/page.json
@@ -1,0 +1,6 @@
+{
+  "object": "page",
+  "id": "page123",
+  "properties": {},
+  "url": "https://www.notion.so/page123"
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
 		"version": "node version-bump.mjs && git add manifest.json package.json versions.json",
-		"lint": "eslint src --ext .ts --fix",
+		"lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\" \"__tests__/**/*.ts\" --fix",
 		"check:glyph-header": "node scripts/glyph-header-check.js",
 		"ci:pr": "node scripts/run-governance-tool.mjs ts check-pr-body.ts",
 		"validate:links": "node scripts/run-governance-tool.mjs ts validate-link-graph.ts",

--- a/src/formats/notion-api.ts
+++ b/src/formats/notion-api.ts
@@ -1,0 +1,30 @@
+// [SIG-FLD-VAL-001] Declared in posture, amplified in field.
+// Notion API importer scaffold: registers an importer with Obsidian runtime (to be wired by host app)
+
+export interface FormatImporter {
+	id: string;
+	label: string;
+	// Initialize with configuration or secrets if needed
+	init?(): Promise<void> | void;
+	// Perform an import run for a given source identifier
+	run(sourceId: string): Promise<void>;
+}
+
+export class NotionApiImporter implements FormatImporter {
+	id = 'notion-api';
+	label = 'Notion (Data Sources)';
+
+	async init(): Promise<void> {
+		// no-op for now
+	}
+
+	async run(_sourceId: string): Promise<void> {
+		// TODO: wire NotionClient + conversion pipeline here
+		return;
+	}
+}
+
+// Factory function for host code to create/register the importer
+export function createNotionApiImporter(): NotionApiImporter {
+	return new NotionApiImporter();
+}

--- a/src/formats/notion-bases.ts
+++ b/src/formats/notion-bases.ts
@@ -1,0 +1,8 @@
+// [SIG-FLD-VAL-001] Declared in posture, amplified in field.
+// Builds .base YAML structures for views/filters/sorts/groups/formulas (scaffold)
+import type { NotionBaseView, NotionBaseConfig } from './notion-types';
+
+export function buildBaseYaml(_config: NotionBaseConfig, _views: NotionBaseView[]): string {
+	// TODO: emit YAML that Obsidian importer can read as a .base file
+	return '# base: TODO\n';
+}

--- a/src/formats/notion-client.ts
+++ b/src/formats/notion-client.ts
@@ -1,0 +1,3 @@
+// [SIG-FLD-VAL-001] Declared in posture, amplified in field.
+// Re-export governed Notion client
+export { NotionClient, type NotionClientOptions, type NotionRequest } from '../network/notionClient';

--- a/src/formats/notion-convert.ts
+++ b/src/formats/notion-convert.ts
@@ -1,0 +1,15 @@
+// [SIG-FLD-VAL-001] Declared in posture, amplified in field.
+// Notion blocks → Markdown conversion (scaffold)
+import type { NotionBlock, NotionPage } from './notion-types';
+
+export type Markdown = string;
+
+export function convertBlockToMarkdown(_block: NotionBlock): Markdown {
+	// TODO: implement paragraphs, bulleted lists, numbered lists, to-dos, tables, equations, embeds …
+	return '';
+}
+
+export function convertPageToMarkdown(_page: NotionPage, _children: NotionBlock[]): Markdown {
+	// TODO: stitch child blocks into a single Markdown document with front matter
+	return '';
+}

--- a/src/formats/notion-schema.ts
+++ b/src/formats/notion-schema.ts
@@ -1,0 +1,8 @@
+// [SIG-FLD-VAL-001] Declared in posture, amplified in field.
+// Maps Data Source property schema → front matter fields (scaffold)
+import type { NotionDataSourceSchema, FrontMatter } from './notion-types';
+
+export function mapSchemaToFrontMatter(_schema: NotionDataSourceSchema): FrontMatter {
+	// TODO: translate Notion property types (title, rich_text, number, select, multi_select, date, relation, formula …)
+	return {};
+}

--- a/src/formats/notion-types.ts
+++ b/src/formats/notion-types.ts
@@ -1,0 +1,33 @@
+// [SIG-FLD-VAL-001] Declared in posture, amplified in field.
+// Minimal Notion types for compilation; extend as needed
+
+export type FrontMatter = Record<string, unknown>;
+
+export interface NotionDataSourceSchema {
+	id: string;
+	properties: Record<string, { type: string, name: string }>;
+}
+
+export interface NotionPage {
+	id: string;
+	title?: string;
+	properties?: Record<string, unknown>;
+}
+
+export interface NotionBlock {
+	id: string;
+	type: string;
+	has_children?: boolean;
+	[key: string]: any; // placeholder for block-specific fields
+}
+
+export interface NotionBaseView {
+	id: string;
+	name: string;
+	type: 'table' | 'board' | 'list' | 'calendar' | 'gallery';
+}
+
+export interface NotionBaseConfig {
+	id: string;
+	name: string;
+}

--- a/src/formats/notion-utils.ts
+++ b/src/formats/notion-utils.ts
@@ -1,0 +1,15 @@
+// [SIG-FLD-VAL-001] Declared in posture, amplified in field.
+// Helper utilities for Notion importer
+
+export function sanitizeId(id: string): string {
+	return id.replace(/[^a-zA-Z0-9_-]+/g, '-');
+}
+
+export function safeFilename(name: string): string {
+	return name.trim().replace(/[\\/:*?"<>|]+/g, '-');
+}
+
+export function formatDate(d: Date): string {
+	// ISO without milliseconds for nicer filenames
+	return d.toISOString().replace(/\..+Z$/, 'Z');
+}

--- a/src/ui/notion-settings.ts
+++ b/src/ui/notion-settings.ts
@@ -1,0 +1,10 @@
+// [SIG-FLD-VAL-001] Declared in posture, amplified in field.
+// Settings UI scaffold (host app must wire this into Obsidian settings)
+export interface NotionSettings {
+	token: string | null;
+	attachmentFolder: string;
+}
+
+export function getDefaultSettings(): NotionSettings {
+	return { token: null, attachmentFolder: 'Notion Attachments' };
+}


### PR DESCRIPTION
# PR Summary

- What change is introduced?
- Why is this necessary now?
- How was this tested?

## Commits
- 9e6205a feat(notion): scaffold importer modules, fixtures, docs; align tests with guidelines; enhance Notion client tests

## Files Changed
- A	__tests__/notion-bases.spec.ts
- A	__tests__/notion-client.spec.ts
- A	__tests__/notion-convert.spec.ts
- A	__tests__/obsidian-guidelines.spec.ts
- A	docs/notion.md
- A	fixtures/notion/blocks.json
- A	fixtures/notion/data_source.json
- A	fixtures/notion/page.json
- A	src/formats/notion-api.ts
- A	src/formats/notion-bases.ts
- A	src/formats/notion-client.ts
- A	src/formats/notion-convert.ts
- A	src/formats/notion-schema.ts
- A	src/formats/notion-types.ts
- A	src/formats/notion-utils.ts
- A	src/ui/notion-settings.ts
- M	tests/network/notionClient.test.ts

## Governance

- Glyph(s) referenced:
  - SIG-FLD-VAL-001 — Declaration Echoes Return Amplified
- Contracts impacted:
\n  - SIG-SYS-NOT-027 — Secrets & Privacy\n  - SIG-SYS-NOT-018 — Rate Limit & Retry\n  - SIG-SYS-NOT-023 — DS Docs Compliance\n  - SIG-SYS-NOT-032 — Back-Compat (downgrade)

## Downgrade Notes (if any)

If using a legacy or less-preferred path (e.g., Notion legacy DB API instead of Data Sources), explain:
- Reason for downgrade:
- Scope and duration:
- Mitigations and plan to restore alignment:

## Checklist

- [x] New/changed source files include the glyph header on the first lines
- [x] Tests run locally (see session-end output)
- [ ] Governance checks will pass in CI

