### PR TITLE
chore: housekeeping – add git-prune script, safer cleanup flow (prune + merged/gone sweeps), verify-before-governance, expand lint scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"smoke": "bash scripts/smoke-meta.sh",
 		"verify": "npm run lint && npm run build",
 		"prepare": "husky install",
+		"prune": "git fetch --prune origin && git remote prune origin && git for-each-ref --format='%(refname:short) %(upstream:trackshort)' refs/heads | awk '$2==\"[gone]\"{print $1}' | xargs -r -n1 git branch -D",
 		"session:start": "bash scripts/session-start.sh",
 		"session:end": "bash scripts/session-end.sh",
 		"session:merge": "bash scripts/session-merge.sh",

--- a/scripts/git-prune.sh
+++ b/scripts/git-prune.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# [SIG-FLD-VAL-001] Declared in posture, amplified in field.
+# Robust prune script (macOS/BSD compatible):
+# - Prune remote-tracking refs
+# - Delete local branches with missing upstream ([gone])
+# - Delete local branches fully merged into main/master
+set -euo pipefail
+
+# Prune remote-tracking refs
+git fetch --prune origin
+# Also prune any stale remotes (safe if none)
+if command -v git >/dev/null 2>&1; then
+  git remote prune origin || true
+fi
+
+# Determine primary branch
+PRIMARY=main
+if git show-ref --verify --quiet refs/heads/main; then
+  PRIMARY=main
+elif git show-ref --verify --quiet refs/heads/master; then
+  PRIMARY=master
+fi
+
+# Delete local branches with [gone] upstream (skip primary)
+echo "Pruning local branches with missing upstream..."
+while IFS= read -r line; do
+  name="${line%% *}"
+  status="${line#* }"
+  if [ "$status" = "[gone]" ] && [ "$name" != "$PRIMARY" ] && [ "$name" != "master" ]; then
+    echo " - deleting (gone upstream): $name"
+    git branch -D "$name" || true
+  fi
+done < <(git for-each-ref --format='%(refname:short) %(upstream:trackshort)' refs/heads)
+
+# Delete branches fully merged into primary
+echo "Pruning local branches merged into $PRIMARY..."
+while IFS= read -r merged; do
+  [ -z "$merged" ] && continue
+  [ "$merged" = "$PRIMARY" ] && continue
+  [ "$merged" = "master" ] && continue
+  echo " - deleting (merged): $merged"
+  git branch -d "$merged" || true
+done < <(git branch --merged "$PRIMARY" | sed 's/^..//')
+
+echo "Prune complete. Current branches:"
+git branch -v

--- a/scripts/session-end.sh
+++ b/scripts/session-end.sh
@@ -71,7 +71,7 @@ REPO="${GH_REPO:-ava-sig/obsidian-importer}"
 BASE_BRANCH="$(git remote show origin | sed -n 's/  HEAD branch: //p')"
 if [ -z "$BASE_BRANCH" ]; then BASE_BRANCH="main"; fi
 
-# Ensure we have the latest refs
+# Ensure we have the latest refs (pruning is handled in session-cleanup)
 git fetch origin
 
 # Ensure upstream is set and push latest commits


### PR DESCRIPTION
# PR Summary

- What change is introduced?
  chore: housekeeping – add git-prune script, safer cleanup flow (prune + merged/gone sweeps), verify-before-governance, expand lint scope

- Why is this necessary now?
  
  - Prepare importer structure for feature work and tests

- How was this tested?
  \n  - Unit tests (vitest):
    *           Tests  9 passed | 3 skipped (12)
  - Governance CI (lint/build enforced pre-checks)

## Commits
- bbd62f1 chore: housekeeping – add git-prune script, safer cleanup flow (prune + merged/gone sweeps), verify-before-governance, expand lint scope

## Files Changed
- M	package.json
- A	scripts/git-prune.sh
- M	scripts/session-cleanup.sh
- M	scripts/session-end.sh

## Governance

- Glyph(s) referenced:
  - SIG-FLD-VAL-001 — Declaration Echoes Return Amplified
- Contracts impacted:
\n  - (none detected)

## Downgrade Notes (if any)

(none)

## Checklist

- [x] New/changed source files include the glyph header on the first lines
- [x] Tests run locally (see session-end output)
- [ ] Governance checks will pass in CI

