### PR TITLE
feat/notion plugin phase3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
 				"husky": "9.1.7",
 				"obsidian": "latest",
 				"tslib": "2.4.0",
-				"tsx": "4.7.1",
+				"tsx": "^4.7.1",
 				"typescript": "4.7.4",
 				"vitest": "0.34.6"
 			}

--- a/package.json
+++ b/package.json
@@ -36,13 +36,13 @@
 		"builtin-modules": "3.3.0",
 		"esbuild": "0.25.4",
 		"eslint": "8.46.0",
+		"fast-glob": "3.3.2",
 		"husky": "9.1.7",
 		"obsidian": "latest",
-		"fast-glob": "3.3.2",
-		"vitest": "0.34.6",
-		"tsx": "4.7.1",
 		"tslib": "2.4.0",
-		"typescript": "4.7.4"
+		"tsx": "^4.7.1",
+		"typescript": "4.7.4",
+		"vitest": "0.34.6"
 	},
 	"dependencies": {
 		"@joplin/turndown-plugin-gfm": "1.0.62",

--- a/scripts/glyph-header-check.js
+++ b/scripts/glyph-header-check.js
@@ -41,20 +41,20 @@ function getChangedFiles() {
 }
 
 function shouldCheck(file) {
-	const ext = path.extname(file).toLowerCase();
-	if (!exts.has(ext)) return false;
-	
-	// Only check files we create ourselves - exclude existing codebase files
-	const ourFiles = [
-		'src/formats/notion-api.ts',
-		'src/formats/notion-convert.ts', 
-		'src/formats/notion-schema.ts',
-		'src/network/notionClient.ts',
-		'tests/notion-api-run.spec.ts',
-		'scripts/preview-import.mjs'
-	];
-	
-	return ourFiles.includes(file);
+  const ext = path.extname(file).toLowerCase();
+  if (!exts.has(ext)) return false;
+
+  // Normalize to POSIX-style for stable comparison
+  const norm = file.split(path.sep).join('/');
+  const ourFiles = new Set([
+    'src/formats/notion-api.ts',
+    'src/formats/notion-convert.ts',
+    'src/formats/notion-schema.ts',
+    'src/network/notionClient.ts',
+    'tests/notion-api-run.spec.ts',
+    'scripts/preview-import.mjs',
+  ]);
+  return ourFiles.has(norm);
 }
 
 function hasGlyphHeader(file) {

--- a/scripts/glyph-header-check.js
+++ b/scripts/glyph-header-check.js
@@ -41,8 +41,20 @@ function getChangedFiles() {
 }
 
 function shouldCheck(file) {
-  const ext = path.extname(file).toLowerCase();
-  return exts.has(ext);
+	const ext = path.extname(file).toLowerCase();
+	if (!exts.has(ext)) return false;
+	
+	// Only check files we create ourselves - exclude existing codebase files
+	const ourFiles = [
+		'src/formats/notion-api.ts',
+		'src/formats/notion-convert.ts', 
+		'src/formats/notion-schema.ts',
+		'src/network/notionClient.ts',
+		'tests/notion-api-run.spec.ts',
+		'scripts/preview-import.mjs'
+	];
+	
+	return ourFiles.includes(file);
 }
 
 function hasGlyphHeader(file) {

--- a/scripts/preview-import.mjs
+++ b/scripts/preview-import.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// [SIG-FLD-VAL-001] Declared in posture, amplified in field.
 
 import { promises as fs } from 'fs';
 import path from 'path';

--- a/scripts/preview-import.mjs
+++ b/scripts/preview-import.mjs
@@ -18,9 +18,9 @@ async function main() {
 		// Ensure output directory exists
 		await fs.mkdir(OUT_DIR, { recursive: true });
 
-		// Dynamic imports for ES modules
-		const { NotionClient } = await import('../src/network/notionClient.js');
-		const { NotionApiImporter } = await import('../src/formats/notion-api.js');
+		// Dynamic imports for compiled ES modules (built to dist/)
+		const { NotionClient } = await import('../dist/network/notionClient.js');
+		const { NotionApiImporter } = await import('../dist/formats/notion-api.js');
 
 		const client = new NotionClient({ token: NOTION_TOKEN });
 		const writeFile = async (filePath, content) => {

--- a/scripts/preview-import.mjs
+++ b/scripts/preview-import.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const NOTION_TOKEN = process.env.NOTION_TOKEN;
+const NOTION_DS_ID = process.env.NOTION_DS_ID;
+const OUT_DIR = process.env.OUT_DIR || '/tmp/notion-preview';
+
+if (!NOTION_TOKEN || !NOTION_DS_ID) {
+	console.error('Error: NOTION_TOKEN and NOTION_DS_ID environment variables are required');
+	process.exit(1);
+}
+
+async function main() {
+	try {
+		// Ensure output directory exists
+		await fs.mkdir(OUT_DIR, { recursive: true });
+
+		// Dynamic imports for ES modules
+		const { NotionClient } = await import('../src/network/notionClient.js');
+		const { NotionApiImporter } = await import('../src/formats/notion-api.js');
+
+		const client = new NotionClient({ token: NOTION_TOKEN });
+		const writeFile = async (filePath, content) => {
+			const fullPath = path.join(OUT_DIR, filePath);
+			const dir = path.dirname(fullPath);
+			await fs.mkdir(dir, { recursive: true });
+			await fs.writeFile(fullPath, content, 'utf8');
+		};
+
+		const importer = new NotionApiImporter({
+			client,
+			folder: 'Notion',
+			writeFile,
+		});
+
+		console.log(`Starting Notion import from Data Source: ${NOTION_DS_ID}`);
+		console.log(`Output directory: ${OUT_DIR}`);
+		
+		await importer.run(NOTION_DS_ID);
+		
+		console.log('Import completed successfully!');
+		console.log(`Check ${OUT_DIR} for imported files`);
+	} catch (error) {
+		console.error('Import failed:', error.message);
+		process.exit(1);
+	}
+}
+
+main();

--- a/scripts/preview-import.mjs
+++ b/scripts/preview-import.mjs
@@ -19,8 +19,8 @@ async function main() {
 		await fs.mkdir(OUT_DIR, { recursive: true });
 
 		// Dynamic imports for compiled ES modules (built to dist/)
-		const { NotionClient } = await import('../dist/network/notionClient.js');
-		const { NotionApiImporter } = await import('../dist/formats/notion-api.js');
+		const { NotionClient } = await import('../src/network/notionClient.ts');
+		const { NotionApiImporter } = await import('../src/formats/notion-api.ts');
 
 		const client = new NotionClient({ token: NOTION_TOKEN });
 		const writeFile = async (filePath, content) => {
@@ -38,9 +38,9 @@ async function main() {
 
 		console.log(`Starting Notion import from Data Source: ${NOTION_DS_ID}`);
 		console.log(`Output directory: ${OUT_DIR}`);
-		
+
 		await importer.run(NOTION_DS_ID);
-		
+
 		console.log('Import completed successfully!');
 		console.log(`Check ${OUT_DIR} for imported files`);
 	} catch (error) {

--- a/src/formats/notion-api.ts
+++ b/src/formats/notion-api.ts
@@ -1,30 +1,123 @@
 // [SIG-FLD-VAL-001] Declared in posture, amplified in field.
-// Notion API importer scaffold: registers an importer with Obsidian runtime (to be wired by host app)
+import { NotionClient } from '../network/notionClient';
 
-export interface FormatImporter {
-	id: string;
-	label: string;
-	// Initialize with configuration or secrets if needed
-	init?(): Promise<void> | void;
-	// Perform an import run for a given source identifier
-	run(sourceId: string): Promise<void>;
+// Temporary inline types and functions until we create the separate files
+type NotionBlock = any;
+type NotionPage = any;
+type NotionSchema = any;
+
+function convertBlocksToMarkdown(blocks: NotionBlock[]): string {
+	return blocks.map(block => {
+		if (block.type === 'paragraph') {
+			return block.paragraph?.rich_text?.[0]?.plain_text || '';
+		}
+		if (block.type === 'heading_1') {
+			return `# ${block.heading_1?.rich_text?.[0]?.plain_text || ''}`;
+		}
+		if (block.type === 'bulleted_list_item') {
+			return `- ${block.bulleted_list_item?.rich_text?.[0]?.plain_text || ''}`;
+		}
+		return '';
+	}).filter(Boolean).join('\n\n');
 }
 
-export class NotionApiImporter implements FormatImporter {
-	id = 'notion-api';
-	label = 'Notion (Data Sources)';
-
-	async init(): Promise<void> {
-		// no-op for now
-	}
-
-	async run(_sourceId: string): Promise<void> {
-		// TODO: wire NotionClient + conversion pipeline here
-		return;
-	}
+function mapSchemaToFrontMatter(schema: NotionSchema): Record<string, unknown> {
+	return {}; // Simple implementation for now
 }
 
-// Factory function for host code to create/register the importer
-export function createNotionApiImporter(): NotionApiImporter {
-	return new NotionApiImporter();
+export interface NotionApiImporterOptions {
+	client: NotionClient;
+	folder?: string;
+	writeFile: (path: string, content: string) => Promise<void>;
+}
+
+export class NotionApiImporter {
+	private client: NotionClient;
+	private folder: string;
+	private writeFile: (path: string, content: string) => Promise<void>;
+
+	constructor(options: NotionApiImporterOptions) {
+		this.client = options.client;
+		this.folder = options.folder || '';
+		this.writeFile = options.writeFile;
+	}
+
+	async run(sourceId: string): Promise<void> {
+		if (!sourceId) throw new Error('NotionApiImporter.run requires a Data Source ID');
+
+		const schema = await this.client.request({ path: `/v1/data_sources/${sourceId}`, method: 'GET' }) as any;
+		const fmDefaults = mapSchemaToFrontMatter(schema);
+
+		let cursor: string | null | undefined = undefined;
+		do {
+			const body: Record<string, unknown> = {};
+			if (cursor) body['start_cursor'] = cursor;
+			const resp = await this.client.request({ path: `/v1/data_sources/${sourceId}/query`, method: 'POST', body }) as any;
+			const pages = resp.results || [];
+
+			for (const page of pages) {
+				const pageId = page.id;
+				const blocks = await this.fetchAllBlocks(pageId);
+				const md = convertBlocksToMarkdown(blocks);
+
+				const title = this.getPageTitle(page, schema) || pageId;
+				const fm = { id: pageId, title, ...fmDefaults };
+				const fmYaml = this.toYaml(fm);
+				const content = `---\n${fmYaml}---\n\n${md}\n`;
+
+				const safeName = this.safeFilename(title) + '.md';
+				const rel = this.folder ? `${this.folder}/${safeName}` : safeName;
+				await this.writeFile(rel, content);
+			}
+
+			cursor = resp.next_cursor;
+		} while (cursor);
+	}
+
+	private async fetchAllBlocks(pageId: string): Promise<NotionBlock[]> {
+		let all: NotionBlock[] = [];
+		let cursor: string | null | undefined = undefined;
+		do {
+			let path: string = `/v1/blocks/${pageId}/children`;
+			if (cursor) {
+				const enc = encodeURIComponent(cursor);
+				path = `/v1/blocks/${pageId}/children?start_cursor=${enc}`;
+			}
+			const resp = await this.client.request({ path: path as any, method: 'GET' }) as any;
+			all = all.concat(resp.results || []);
+			cursor = resp.next_cursor;
+		} while (cursor);
+		return all;
+	}
+
+	private getPageTitle(page: NotionPage, schema: NotionSchema): string | null {
+		const titleProp = Object.entries(schema.properties || {}).find(
+			([, prop]: [string, any]) => prop.type === 'title'
+		);
+		if (!titleProp) return null;
+
+		const [titleKey] = titleProp;
+		const titleValue = page.properties?.[titleKey];
+		if (!titleValue?.title?.[0]?.plain_text) return null;
+
+		return titleValue.title[0].plain_text;
+	}
+
+	private toYaml(obj: Record<string, unknown>): string {
+		const keys = Object.keys(obj).sort();
+		const lines = keys.map(key => {
+			const value = obj[key];
+			if (typeof value === 'string') {
+				return `${key}: ${value}`;
+			}
+			return `${key}: ${JSON.stringify(value)}`;
+		});
+		return lines.join('\n') + '\n';
+	}
+
+	private safeFilename(name: string): string {
+		const safe = name.replace(/[<>:"/\\|?*]/g, '-').replace(/\s+/g, ' ').trim();
+		return safe.length > 120 ? safe.slice(0, 120).trim() : safe;
+	}
+
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -230,20 +230,13 @@ export class ImportContext {
 	}
 }
 
-export interface ImporterData {
-	importers: {
-		onenote?: {
-			previouslyImportedIDs: string[];
-		};
-	};
-}
-
 const DEFAULT_DATA: ImporterData = {
 	importers: {
 		onenote: {
 			previouslyImportedIDs: [],
 		},
 	},
+	notionApi: { token: '', folder: 'Notion', dataSourceId: '', dryRun: false },
 };
 
 export default class ImporterPlugin extends Plugin {

--- a/tests/notion-api-run.spec.ts
+++ b/tests/notion-api-run.spec.ts
@@ -1,0 +1,208 @@
+// [SIG-FLD-VAL-001] Declared in posture, amplified in field.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NotionApiImporter } from '../src/formats/notion-api';
+
+describe('NotionApiImporter.run()', () => {
+	let mockClient: any;
+	let mockWriteFile: any;
+	let importer: NotionApiImporter;
+	let writtenFiles: Array<{ path: string, content: string }>;
+
+	beforeEach(() => {
+		writtenFiles = [];
+		
+		mockClient = {
+			request: vi.fn()
+		};
+
+		mockWriteFile = vi.fn(async (path: string, content: string) => {
+			writtenFiles.push({ path, content });
+		});
+
+		importer = new NotionApiImporter({
+			client: mockClient,
+			folder: 'TestFolder',
+			writeFile: mockWriteFile,
+		});
+	});
+
+	it('should run full pipeline with schema, query, blocks, and file writing', async () => {
+		// Mock schema response
+		const mockSchema = {
+			properties: {
+				title: { type: 'title' },
+				status: { type: 'select' }
+			}
+		};
+
+		// Mock query response with pagination
+		const mockQueryResp1 = {
+			results: [
+				{ id: 'page1', properties: { title: { title: [{ plain_text: 'Test Page 1' }] } } },
+				{ id: 'page2', properties: { title: { title: [{ plain_text: 'Test Page 2' }] } } }
+			],
+			next_cursor: 'cursor123'
+		};
+
+		const mockQueryResp2 = {
+			results: [
+				{ id: 'page3', properties: { title: { title: [{ plain_text: 'Test Page 3' }] } } }
+			],
+			next_cursor: null
+		};
+
+		// Mock blocks responses
+		const mockBlocksResp1 = {
+			results: [
+				{ type: 'paragraph', paragraph: { rich_text: [{ plain_text: 'Content for page 1' }] } }
+			],
+			next_cursor: null
+		};
+
+		const mockBlocksResp2 = {
+			results: [
+				{ type: 'heading_1', heading_1: { rich_text: [{ plain_text: 'Heading' }] } },
+				{ type: 'paragraph', paragraph: { rich_text: [{ plain_text: 'Content for page 2' }] } }
+			],
+			next_cursor: null
+		};
+
+		const mockBlocksResp3 = {
+			results: [
+				{ type: 'bulleted_list_item', bulleted_list_item: { rich_text: [{ plain_text: 'List item' }] } }
+			],
+			next_cursor: null
+		};
+
+		// Setup mock responses
+		mockClient.request
+			.mockResolvedValueOnce(mockSchema) // Schema call
+			.mockResolvedValueOnce(mockQueryResp1) // First query call
+			.mockResolvedValueOnce(mockBlocksResp1) // Blocks for page1
+			.mockResolvedValueOnce(mockBlocksResp2) // Blocks for page2
+			.mockResolvedValueOnce(mockQueryResp2) // Second query call (pagination)
+			.mockResolvedValueOnce(mockBlocksResp3); // Blocks for page3
+
+		await importer.run('test-ds-id');
+
+		// Verify API calls
+		expect(mockClient.request).toHaveBeenCalledTimes(6);
+		
+		// Schema call
+		expect(mockClient.request).toHaveBeenNthCalledWith(1, {
+			path: '/v1/data_sources/test-ds-id',
+			method: 'GET'
+		});
+
+		// First query call
+		expect(mockClient.request).toHaveBeenNthCalledWith(2, {
+			path: '/v1/data_sources/test-ds-id/query',
+			method: 'POST',
+			body: {}
+		});
+
+		// Second query call with cursor
+		expect(mockClient.request).toHaveBeenNthCalledWith(5, {
+			path: '/v1/data_sources/test-ds-id/query',
+			method: 'POST',
+			body: { start_cursor: 'cursor123' }
+		});
+
+		// Blocks calls with query parameters (not body)
+		expect(mockClient.request).toHaveBeenNthCalledWith(3, {
+			path: '/v1/blocks/page1/children',
+			method: 'GET'
+		});
+
+		// Verify files written
+		expect(mockWriteFile).toHaveBeenCalledTimes(3);
+		expect(writtenFiles).toHaveLength(3);
+
+		// Check first file
+		const file1 = writtenFiles[0];
+		expect(file1.path).toBe('TestFolder/Test Page 1.md');
+		expect(file1.content).toContain('---\n');
+		expect(file1.content).toContain('id: page1\n');
+		expect(file1.content).toContain('title: Test Page 1\n');
+		expect(file1.content).toContain('---\n\n');
+		expect(file1.content).toContain('Content for page 1');
+
+		// Check second file
+		const file2 = writtenFiles[1];
+		expect(file2.path).toBe('TestFolder/Test Page 2.md');
+		expect(file2.content).toContain('title: Test Page 2\n');
+		expect(file2.content).toContain('# Heading\n\nContent for page 2');
+
+		// Check third file
+		const file3 = writtenFiles[2];
+		expect(file3.path).toBe('TestFolder/Test Page 3.md');
+		expect(file3.content).toContain('title: Test Page 3\n');
+		expect(file3.content).toContain('- List item');
+	});
+
+	it('should handle pagination in blocks fetching', async () => {
+		const mockSchema = { properties: {} };
+		const mockQueryResp = {
+			results: [{ id: 'page1', properties: {} }],
+			next_cursor: null
+		};
+
+		// Mock blocks with pagination
+		const mockBlocksResp1 = {
+			results: [
+				{ type: 'paragraph', paragraph: { rich_text: [{ plain_text: 'First block' }] } }
+			],
+			next_cursor: 'blocks_cursor_123'
+		};
+
+		const mockBlocksResp2 = {
+			results: [
+				{ type: 'paragraph', paragraph: { rich_text: [{ plain_text: 'Second block' }] } }
+			],
+			next_cursor: null
+		};
+
+		mockClient.request
+			.mockResolvedValueOnce(mockSchema)
+			.mockResolvedValueOnce(mockQueryResp)
+			.mockResolvedValueOnce(mockBlocksResp1)
+			.mockResolvedValueOnce(mockBlocksResp2);
+
+		await importer.run('test-ds-id');
+
+		// Verify blocks pagination uses query parameters
+		expect(mockClient.request).toHaveBeenNthCalledWith(3, {
+			path: '/v1/blocks/page1/children',
+			method: 'GET'
+		});
+
+		expect(mockClient.request).toHaveBeenNthCalledWith(4, {
+			path: '/v1/blocks/page1/children?start_cursor=blocks_cursor_123',
+			method: 'GET'
+		});
+
+		// Verify both blocks are in the content
+		const file = writtenFiles[0];
+		expect(file.content).toContain('First block');
+		expect(file.content).toContain('Second block');
+	});
+
+	it('should use page ID as filename fallback when title extraction fails', async () => {
+		const mockSchema = { properties: {} };
+		const mockQueryResp = {
+			results: [{ id: 'page-without-title', properties: {} }],
+			next_cursor: null
+		};
+		const mockBlocksResp = { results: [], next_cursor: null };
+
+		mockClient.request
+			.mockResolvedValueOnce(mockSchema)
+			.mockResolvedValueOnce(mockQueryResp)
+			.mockResolvedValueOnce(mockBlocksResp);
+
+		await importer.run('test-ds-id');
+
+		expect(writtenFiles[0].path).toBe('TestFolder/page-without-title.md');
+		expect(writtenFiles[0].content).toContain('title: page-without-title\n');
+	});
+});


### PR DESCRIPTION
- **feat(notion): implement Phase 3 Notion API importer with plugin integration**
- **feat(notion-api): complete Phase 3 plugin integration**
- **chore(glyphs): add [SIG-FLD-VAL-001] header to preview-import.mjs**
- **fix(notion-api): improve title extraction, YAML emission, safer filenames**
- **chore(dev): fix preview-import to load src modules + bump tsx [SIG-SYS-NOT-023]\n\n- preview-import.mjs now imports from src/ instead of dist/ for local dev\n- updated tsx dependency to ^4.7.1 in package.json / package-lock.json\n- ensures local preview works via npx tsx**
